### PR TITLE
feat(dialogue portraits): expose current event, support changing within a single page

### DIFF
--- a/src/dialogue portraits.js
+++ b/src/dialogue portraits.js
@@ -112,7 +112,10 @@ if (portraitVars.DEFAULT_SIDE !== 0 && portraitVars.DEFAULT_SIDE !== 1) {
 
 // #region TRACK THE CURRENTLY RUN EVENT
 wrap.before(BipsiPlayback.prototype, 'runJS', (event, js, debug) => {
-	portraitVars.currentEvent = event;
+	if (PLAYBACK)
+	{
+		PLAYBACK.jsSourceEvent = event;
+	}
 });
 // #endregion
 
@@ -146,7 +149,7 @@ wrap.before(DialoguePlayback.prototype, 'applyStyle', () => {
 			portraitVars.currentBgColorIndex = parseInt(args[3], 10);
 			portraitVars.currentBorderColorIndex = parseInt(args[4], 10);
 			// Use the portraited event's colors as defaults.
-			const eventColors = FIELD(portraitVars.currentEvent, 'colors', 'colors') || { fg: 3, bg: 1 };
+			const eventColors = FIELD(PLAYBACK.jsSourceEvent, 'colors', 'colors') || { fg: 3, bg: 1 };
 			if ((!portraitId && portraitId !== 0) || portraitId < -1) {
 				portraitId = null; // No portrait shown
 			}
@@ -165,7 +168,6 @@ wrap.before(DialoguePlayback.prototype, 'applyStyle', () => {
 
 			// Work out the portrait info to be rendered
 			gatherPortraitData(portraitId);
-			// Delete the portrait style.  It's applied now and shouldn't be re-applied hereafter.
 			glyph.styles.delete('portrait');
 		}
 	});
@@ -196,7 +198,7 @@ function gatherPortraitData(portraitId) {
 	} else {
 		// Setup portrait from image
 		const portraitIdParts = portraitId.split('-');
-		const srcEvent = portraitIdParts.length === 1 ? portraitVars.currentEvent : window.findEventByTag(window.PLAYBACK.data, portraitIdParts[0]);
+		const srcEvent = portraitIdParts.length === 1 ? PLAYBACK.jsSourceEvent : window.findEventByTag(window.PLAYBACK.data, portraitIdParts[0]);
 		if (!srcEvent) {
 			return;
 		}

--- a/src/dialogue portraits.js
+++ b/src/dialogue portraits.js
@@ -112,8 +112,8 @@ if (portraitVars.DEFAULT_SIDE !== 0 && portraitVars.DEFAULT_SIDE !== 1) {
 
 // #region TRACK THE CURRENTLY RUN EVENT
 wrap.before(BipsiPlayback.prototype, 'runJS', (event, js, debug) => {
-	if (PLAYBACK) {
-		PLAYBACK.jsSourceEvent = event;
+	if (window.PLAYBACK) {
+		window.PLAYBACK.jsSourceEvent = event;
 	}
 });
 // #endregion
@@ -148,7 +148,7 @@ wrap.before(DialoguePlayback.prototype, 'applyStyle', () => {
 			portraitVars.currentBgColorIndex = parseInt(args[3], 10);
 			portraitVars.currentBorderColorIndex = parseInt(args[4], 10);
 			// Use the portraited event's colors as defaults.
-			const eventColors = FIELD(PLAYBACK.jsSourceEvent, 'colors', 'colors') || { fg: 3, bg: 1 };
+			const eventColors = FIELD(window.PLAYBACK.jsSourceEvent, 'colors', 'colors') || { fg: 3, bg: 1 };
 			if ((!portraitId && portraitId !== 0) || portraitId < -1) {
 				portraitId = null; // No portrait shown
 			}
@@ -197,7 +197,7 @@ function gatherPortraitData(portraitId) {
 	} else {
 		// Setup portrait from image
 		const portraitIdParts = portraitId.split('-');
-		const srcEvent = portraitIdParts.length === 1 ? PLAYBACK.jsSourceEvent : window.findEventByTag(window.PLAYBACK.data, portraitIdParts[0]);
+		const srcEvent = portraitIdParts.length === 1 ? window.PLAYBACK.jsSourceEvent : window.findEventByTag(window.PLAYBACK.data, portraitIdParts[0]);
 		if (!srcEvent) {
 			return;
 		}

--- a/src/dialogue portraits.js
+++ b/src/dialogue portraits.js
@@ -112,8 +112,7 @@ if (portraitVars.DEFAULT_SIDE !== 0 && portraitVars.DEFAULT_SIDE !== 1) {
 
 // #region TRACK THE CURRENTLY RUN EVENT
 wrap.before(BipsiPlayback.prototype, 'runJS', (event, js, debug) => {
-	if (PLAYBACK)
-	{
+	if (PLAYBACK) {
 		PLAYBACK.jsSourceEvent = event;
 	}
 });


### PR DESCRIPTION
- the current event is now stored within PLAYBACK for universal accessibility (beyond this plugin).
- now allows changing the portrait within a single dialogue page.
- "portrait" dialogue style is now set on an inserted invisible character, rather than being added to the next available character.
- portraits are not shown until the dialogue character with the "portrait" style is unhidden.
- portraits are set only once, when the "portrait" style is first encountered, and not thereafter.