### PR TITLE
sounds.js - touch-sound field can now be text

### DIFF
--- a/src/sounds.js
+++ b/src/sounds.js
@@ -168,7 +168,7 @@ SCRIPTING_FUNCTIONS.SET_MUSIC_VOLUME = function SET_MUSIC_VOLUME(volume) {
 };
 
 const BEHAVIOUR_TOUCH_SOUND = `
-const sound = FIELD(EVENT, "touch-sound", "file");
+const sound = FIELD(EVENT, "touch-sound");
 if (sound) {
 	PLAY_SOUND(sound);
 }


### PR DESCRIPTION
'touch-sound' fields can now be a text which names which sound file field in the library to play.
EDIT: Low priority.