### PR TITLE
New plugin (editor plugin) - editor fullscreen

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,6 +15,7 @@
 		"CONFIG": "readonly",
 		"BipsiPlayback": "readonly",
 		"DialoguePlayback": "readonly",
+		"BipsiEditor": "readonly",
 		"SCRIPTING_FUNCTIONS": "readonly",
 		"STANDARD_SCRIPTS": "readonly",
 		"wrap": "readonly"

--- a/src/editor fullscreen.js
+++ b/src/editor fullscreen.js
@@ -29,7 +29,7 @@ NOTE: if this plugin's configuration is changed, the key to press may not be 'en
 
 function setupFullscreenToggle() {
 	// Fullscreen toggle logic
-	EDITOR.toggleFullscreen = function toggleFullscreen() {
+	window.EDITOR.toggleFullscreen = function toggleFullscreen() {
 		const canvas = this.playtestIframe.contentWindow.document.getElementById('player-canvas');
 		if (!canvas) return;
 		if (!document.fullscreenElement && !document.mozFullScreenElement && !document.webkitFullscreenElement && !document.msFullscreenElement) {
@@ -64,12 +64,12 @@ function setupFullscreenToggle() {
 	fullscreenButton.classList.add('icon-button');
 	fullscreenButton.title = 'toggle fullscreen';
 	fullscreenButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewbox="0 0 16 16" stroke="currentColor" stroke-linecap="round" fill="none" stroke-width="1.25"><path d="M5 2h-3v3"/><path d="M11 2h3v3"/><path d="M2 11v3h3"/><path d="M14 11v3h-3"/></svg>`;
-	fullscreenButton.addEventListener('click', EDITOR.toggleFullscreen.bind(EDITOR));
+	fullscreenButton.addEventListener('click', window.EDITOR.toggleFullscreen.bind(EDITOR));
 
 	// Hotkey value
 	let hotkey;
 	function updateHotkey() {
-		const event = findEventById(EDITOR.stateManager.present, EVENT_ID);
+		const event = findEventById(window.EDITOR.stateManager.present, EVENT_ID);
 		hotkey = FIELD(event, 'fullscreen-hotkey', 'text').trim() || 'Enter';
 	}
 	wrap.before(BipsiEditor.prototype, 'playtest', updateHotkey);
@@ -78,17 +78,17 @@ function setupFullscreenToggle() {
 	// Hotkey event
 	document.addEventListener('keydown', e => {
 		if (e.key === hotkey) {
-			EDITOR.toggleFullscreen();
+			window.EDITOR.toggleFullscreen();
 		}
 	});
 
 	// Prevent repeating this setup
-	EDITOR.loadedEditorPlugins ||= new Set();
-	EDITOR.loadedEditorPlugins.add('fullscreen');
+	window.EDITOR.loadedEditorPlugins ||= new Set();
+	window.EDITOR.loadedEditorPlugins.add('fullscreen');
 }
 
 // Setup the plugin, if not already setup
-if (!EDITOR.loadedEditorPlugins?.has('fullscreen')) {
+if (!window.EDITOR.loadedEditorPlugins?.has('fullscreen')) {
 	setupFullscreenToggle();
 }
 

--- a/src/editor fullscreen.js
+++ b/src/editor fullscreen.js
@@ -29,7 +29,7 @@ NOTE: if this plugin's configuration is changed, the key to press may not be 'en
 
 function setupEditorPlugin() {
 	// Fullscreen toggle logic
-	window.EDITOR.toggleFullscreen = function toggleFullscreen() {
+	BipsiEditor.prototype.toggleFullscreen = function toggleFullscreen() {
 		const canvas = this.playtestIframe.contentWindow.document.getElementById('player-canvas');
 		if (!canvas) return;
 		if (!document.fullscreenElement && !document.mozFullScreenElement && !document.webkitFullscreenElement && !document.msFullscreenElement) {
@@ -64,7 +64,7 @@ function setupEditorPlugin() {
 	fullscreenButton.classList.add('icon-button');
 	fullscreenButton.title = 'toggle fullscreen';
 	fullscreenButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewbox="0 0 16 16" stroke="currentColor" stroke-linecap="round" fill="none" stroke-width="1.25"><path d="M5 2h-3v3"/><path d="M11 2h3v3"/><path d="M2 11v3h3"/><path d="M14 11v3h-3"/></svg>`;
-	fullscreenButton.addEventListener('click', window.EDITOR.toggleFullscreen.bind(window.EDITOR));
+	fullscreenButton.addEventListener('click', BipsiEditor.prototype.toggleFullscreen.bind(window.EDITOR));
 
 	// Hotkey
 	document.addEventListener('keydown', e => {

--- a/src/editor fullscreen.js
+++ b/src/editor fullscreen.js
@@ -69,7 +69,7 @@ function setupFullscreenToggle() {
 	// Hotkey value
 	let hotkey;
 	function updateHotkey() {
-		const event = findEventById(window.EDITOR.stateManager.present, EVENT_ID);
+		const event = window.findEventById(window.EDITOR.stateManager.present, EVENT_ID);
 		hotkey = FIELD(event, 'fullscreen-hotkey', 'text').trim() || 'Enter';
 	}
 	wrap.before(BipsiEditor.prototype, 'playtest', updateHotkey);

--- a/src/editor fullscreen.js
+++ b/src/editor fullscreen.js
@@ -28,8 +28,6 @@ NOTE: if this plugin's configuration is changed, the key to press may not be 'en
 //! CODE_EDITOR
 
 function setupFullscreenToggle() {
-	const KEY_FOR_FULLSCREEN = FIELD(CONFIG, 'fullscreen-keycode', 'text') || 'Enter';
-
 	// Fullscreen toggle logic
 	EDITOR.toggleFullscreen = function toggleFullscreen() {
 		const canvas = this.playtestIframe.contentWindow.document.getElementById('player-canvas');
@@ -68,9 +66,18 @@ function setupFullscreenToggle() {
 	fullscreenButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewbox="0 0 16 16" stroke="currentColor" stroke-linecap="round" fill="none" stroke-width="1.25"><path d="M5 2h-3v3"/><path d="M11 2h3v3"/><path d="M2 11v3h3"/><path d="M14 11v3h-3"/></svg>`;
 	fullscreenButton.addEventListener('click', EDITOR.toggleFullscreen.bind(EDITOR));
 
-	// Hotkey
+	// Hotkey value
+	let hotkey;
+	function updateHotkey() {
+		const event = findEventById(EDITOR.stateManager.present, EVENT_ID);
+		hotkey = FIELD(event, 'fullscreen-hotkey', 'text').trim() || 'Enter';
+	}
+	wrap.before(BipsiEditor.prototype, 'playtest', updateHotkey);
+	updateHotkey();
+
+	// Hotkey event
 	document.addEventListener('keydown', e => {
-		if (e.key === KEY_FOR_FULLSCREEN) {
+		if (e.key === hotkey) {
 			EDITOR.toggleFullscreen();
 		}
 	});
@@ -88,9 +95,9 @@ if (!EDITOR.loadedEditorPlugins?.has('fullscreen')) {
 //! CODE_RUNTIME_DEV
 
 // Add fullscreen hotkey while the playtest canvas has the focused (i.e. while playtesting the game)
-const KEY_FOR_FULLSCREEN = FIELD(CONFIG, 'fullscreen-keycode', 'text') || 'Enter';
+const FULLSCREEN_HOTKEY = FIELD(CONFIG, 'fullscreen-hotkey', 'text').trim() || 'Enter';
 document.addEventListener('keydown', e => {
-	if (e.key === KEY_FOR_FULLSCREEN) {
+	if (e.key === FULLSCREEN_HOTKEY) {
 		window.parent.window.EDITOR.toggleFullscreen();
 	}
 });

--- a/src/editor fullscreen.js
+++ b/src/editor fullscreen.js
@@ -1,0 +1,94 @@
+/**
+🖥️
+@file editor fullscreen
+@summary Add a ui button and hotkey to the editor to toggle fullscreen while playtesting the game.
+@license MIT
+@author Violgamba (Jon Heard)
+
+@description
+Add a ui button and hotkey to the editor to toggle fullscreen mode while playtesting the game.
+If 'gamepad-input' plugin is used, a gamepad's 'start' button triggers the 'enter' key.  This is
+why 'enter' is the default fullscreen hotkey, to allow toggling fullscreen from a gamepad.
+
+
+HOW TO USE:
+1. Import this plugin into your game.
+2. Run the game.
+3. Press the 'enter' key.  Note that the game becomes fullscreen.
+4. Press the 'enter' key again.  Note that the game becomes non-fullscreen.
+5. Find the fullscreen button on the lower left of the ui (while the game is running).
+6. Press the fullscreen button.  Note that the game becomes fullscreen.
+NOTE: if this plugin's configuration is changed, the key to press may not be 'enter'.
+
+
+// Which keyboard key triggers fullscreen
+//!CONFIG fullscreen-hotkey (text) "Enter"
+*/
+
+//! CODE_EDITOR
+
+function setupFullscreenToggle() {
+	const KEY_FOR_FULLSCREEN = FIELD(CONFIG, 'fullscreen-keycode', 'text') || 'Enter';
+
+	// Fullscreen toggle logic
+	EDITOR.toggleFullscreen = function toggleFullscreen() {
+		const canvas = this.playtestIframe.contentWindow.document.getElementById('player-canvas');
+		if (!canvas) {
+			return;
+		}
+		if (!document.fullscreenElement && !document.mozFullScreenElement && !document.webkitFullscreenElement && !document.msFullscreenElement) {
+			if (canvas.requestFullscreen) {
+				canvas.requestFullscreen();
+			} else if (document.documentElement.msRequestFullscreen) {
+				canvas.msRequestFullscreen();
+			} else if (document.documentElement.mozRequestFullScreen) {
+				canvas.mozRequestFullScreen();
+			} else if (document.documentElement.webkitRequestFullscreen) {
+				canvas.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
+			}
+		} else {
+			// eslint-disable-next-line no-lonely-if
+			if (document.exitFullscreen) {
+				document.exitFullscreen();
+			} else if (document.msExitFullscreen) {
+				document.msExitFullscreen();
+			} else if (document.mozCancelFullScreen) {
+				document.mozCancelFullScreen();
+			} else if (document.webkitExitFullscreen) {
+				document.webkitExitFullscreen();
+			}
+		}
+	};
+
+	// Playtest toolbar button
+	const playtestToolbar = document.getElementById('play-tab-view').children[1];
+	const fullscreenButton = document.createElement('button');
+	playtestToolbar.prepend(fullscreenButton);
+	fullscreenButton.id = 'fullscreenButton';
+	fullscreenButton.classList.add('icon-button');
+	fullscreenButton.title = 'toggle fullscreen';
+	fullscreenButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewbox="0 0 16 16" stroke="currentColor" stroke-linecap="round" fill="none" stroke-width="1.25"><path d="M5 2h-3v3"/><path d="M11 2h3v3"/><path d="M2 11v3h3"/><path d="M14 11v3h-3"/></svg>`;
+	fullscreenButton.addEventListener('click', EDITOR.toggleFullscreen.bind(EDITOR));
+
+	// Hotkey
+	document.addEventListener('keydown', e => {
+		if (e.key === KEY_FOR_FULLSCREEN) {
+			EDITOR.toggleFullscreen();
+		}
+	});
+}
+
+// Setup the plugin, if not already setup
+if (!document.getElementById('fullscreenButton')) {
+	setupFullscreenToggle();
+}
+
+//! CODE_RUNTIME_DEV
+
+// Add fullscreen hotkey while the playtest canvas has the focused (i.e. while playtesting the game)
+const KEY_FOR_FULLSCREEN = FIELD(CONFIG, 'fullscreen-keycode', 'text') || 'Enter';
+document.addEventListener('keydown', e => {
+	if (e.key === KEY_FOR_FULLSCREEN) {
+		window.parent.window.EDITOR.toggleFullscreen();
+	}
+});

--- a/src/editor fullscreen.js
+++ b/src/editor fullscreen.js
@@ -64,7 +64,7 @@ function setupEditorPlugin() {
 	fullscreenButton.classList.add('icon-button');
 	fullscreenButton.title = 'toggle fullscreen';
 	fullscreenButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewbox="0 0 16 16" stroke="currentColor" stroke-linecap="round" fill="none" stroke-width="1.25"><path d="M5 2h-3v3"/><path d="M11 2h3v3"/><path d="M2 11v3h3"/><path d="M14 11v3h-3"/></svg>`;
-	fullscreenButton.addEventListener('click', window.EDITOR.toggleFullscreen.bind(EDITOR));
+	fullscreenButton.addEventListener('click', window.EDITOR.toggleFullscreen.bind(window.EDITOR));
 
 	// Hotkey
 	document.addEventListener('keydown', e => {

--- a/src/editor fullscreen.js
+++ b/src/editor fullscreen.js
@@ -81,7 +81,7 @@ if (!window.EDITOR.loadedEditorPlugins?.has('fullscreen')) {
 	setupEditorPlugin();
 }
 
-//! CODE_RUNTIME_DEV
+//! CODE_PLAYBACK_DEV
 
 // Add fullscreen hotkey while the playtest canvas has the focused (i.e. while playtesting the game)
 const FULLSCREEN_HOTKEY = FIELD(CONFIG, 'fullscreen-hotkey', 'text').trim() || 'Enter';

--- a/src/editor fullscreen.js
+++ b/src/editor fullscreen.js
@@ -33,9 +33,7 @@ function setupFullscreenToggle() {
 	// Fullscreen toggle logic
 	EDITOR.toggleFullscreen = function toggleFullscreen() {
 		const canvas = this.playtestIframe.contentWindow.document.getElementById('player-canvas');
-		if (!canvas) {
-			return;
-		}
+		if (!canvas) return;
 		if (!document.fullscreenElement && !document.mozFullScreenElement && !document.webkitFullscreenElement && !document.msFullscreenElement) {
 			if (canvas.requestFullscreen) {
 				canvas.requestFullscreen();
@@ -76,10 +74,14 @@ function setupFullscreenToggle() {
 			EDITOR.toggleFullscreen();
 		}
 	});
+
+	// Prevent repeating this setup
+	EDITOR.loadedEditorPlugins ||= new Set();
+	EDITOR.loadedEditorPlugins.add('fullscreen');
 }
 
 // Setup the plugin, if not already setup
-if (!document.getElementById('fullscreenButton')) {
+if (!EDITOR.loadedEditorPlugins?.has('fullscreen')) {
 	setupFullscreenToggle();
 }
 

--- a/src/editor fullscreen.js
+++ b/src/editor fullscreen.js
@@ -27,7 +27,7 @@ NOTE: if this plugin's configuration is changed, the key to press may not be 'en
 
 //! CODE_EDITOR
 
-function setupFullscreenToggle() {
+function setupEditorPlugin() {
 	// Fullscreen toggle logic
 	window.EDITOR.toggleFullscreen = function toggleFullscreen() {
 		const canvas = this.playtestIframe.contentWindow.document.getElementById('player-canvas');
@@ -66,18 +66,9 @@ function setupFullscreenToggle() {
 	fullscreenButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewbox="0 0 16 16" stroke="currentColor" stroke-linecap="round" fill="none" stroke-width="1.25"><path d="M5 2h-3v3"/><path d="M11 2h3v3"/><path d="M2 11v3h3"/><path d="M14 11v3h-3"/></svg>`;
 	fullscreenButton.addEventListener('click', window.EDITOR.toggleFullscreen.bind(EDITOR));
 
-	// Hotkey value
-	let hotkey;
-	function updateHotkey() {
-		const event = window.findEventById(window.EDITOR.stateManager.present, EVENT_ID);
-		hotkey = FIELD(event, 'fullscreen-hotkey', 'text').trim() || 'Enter';
-	}
-	wrap.before(BipsiEditor.prototype, 'playtest', updateHotkey);
-	updateHotkey();
-
-	// Hotkey event
+	// Hotkey
 	document.addEventListener('keydown', e => {
-		if (e.key === hotkey) {
+		if (e.key === (FIELD(CONFIG, 'fullscreen-hotkey', 'text').trim() || 'Enter')) {
 			window.EDITOR.toggleFullscreen();
 		}
 	});
@@ -86,10 +77,8 @@ function setupFullscreenToggle() {
 	window.EDITOR.loadedEditorPlugins ||= new Set();
 	window.EDITOR.loadedEditorPlugins.add('fullscreen');
 }
-
-// Setup the plugin, if not already setup
 if (!window.EDITOR.loadedEditorPlugins?.has('fullscreen')) {
-	setupFullscreenToggle();
+	setupEditorPlugin();
 }
 
 //! CODE_RUNTIME_DEV

--- a/src/sound dialogue.js
+++ b/src/sound dialogue.js
@@ -40,7 +40,7 @@ function addEmptyCharToFont(font) {
 	}
 }
 
-wrap.splice(DialoguePlayback.prototype, 'queue', function queuePortrait(original, script, options) {
+wrap.splice(DialoguePlayback.prototype, 'queue', function queueSound(original, script, options) {
 	// Make sure the font includes a zero-width character
 	addEmptyCharToFont(this.getOptions(options).font);
 	// Replace sound markup with a sound style


### PR DESCRIPTION
This is a pretty basic plugin, and an update to something you saw earlier.  It's an editor plugin, which Candle just added support for in Bipsi.  I don't know if you want to separate editor plugins from game plugins in the list.  It's not necessarily a binary designation, though I suspect most plugins will either be "editor" or "game".

In case you aren't familiar with the editor plugin system:
- Any code following `//! CODE_RUNTIME`, or any code that doesn't foll under one of these special comments (all plugins up till now) will be handled like normal plugin code: added to the game in the editor's playtest mode AND added to the game when exported.
- Any code following `//! CODE_EDITOR` is run ONLY in the editor: (1) when the plugin is first added (2) when the app is first loaded and (3) when a game is imported.
- Any code following `//! CODE_RUNTIME_DEV` is added to the game, but only in the editor's playtest mode: it's NOT added to the game when exported.

FYI, I've got 3 other editor plugins that are waiting on code-polish before submitting to you.

I hope you don't mind all these new submissions I'm sending your way.
