### PR TITLE
bug fix - missing CONFIG parameter field causes console error log.

### DIFF
--- a/src/editor fullscreen.js
+++ b/src/editor fullscreen.js
@@ -68,7 +68,7 @@ function setupEditorPlugin() {
 
 	// Hotkey
 	document.addEventListener('keydown', e => {
-		if (e.key === (FIELD(CONFIG, 'fullscreen-hotkey', 'text').trim() || 'Enter')) {
+		if (e.key === (FIELD(CONFIG, 'fullscreen-hotkey', 'text')?.trim() || 'Enter')) {
 			window.EDITOR.toggleFullscreen();
 		}
 	});
@@ -84,7 +84,7 @@ if (!window.EDITOR.loadedEditorPlugins?.has('fullscreen')) {
 //! CODE_PLAYBACK_DEV
 
 // Add fullscreen hotkey while the playtest canvas has the focused (i.e. while playtesting the game)
-const FULLSCREEN_HOTKEY = FIELD(CONFIG, 'fullscreen-hotkey', 'text').trim() || 'Enter';
+const FULLSCREEN_HOTKEY = FIELD(CONFIG, 'fullscreen-hotkey', 'text')?.trim() || 'Enter';
 document.addEventListener('keydown', e => {
 	if (e.key === FULLSCREEN_HOTKEY) {
 		window.parent.window.EDITOR.toggleFullscreen();


### PR DESCRIPTION
Most likely cause: 'fullscreen-hotkey' field is deleted.
Alternate cause: plugin is added and removed, then another event is added, which takes over the event id, but doesn't have the expected parameters.