### PR TITLE
Primarily - made this plugin work for dialogue preview in the editor.

### DIFF
--- a/src/dialogue portraits.js
+++ b/src/dialogue portraits.js
@@ -65,6 +65,10 @@ B - The background color used for a tile portrait.  This is an index into the cu
 O - The border color used for a tile OR image portrait.  This is an index into the current palette
     (1-7).  This defaults to the ui dialogue's back color.  0, will use that default.
 
+// This plugin is run in both the editor and at runtime
+//! CODE_ALL_TYPES
+/*
+
 // The portrait's size
 //!CONFIG scale (json) 4
 
@@ -77,8 +81,6 @@ O - The border color used for a tile OR image portrait.  This is an index into t
 // What color to use as the portrait's border.  If 0, the dialogue-ui's back color is used.
 //!CONFIG default-border-palette-color (json) 0
 */
-
-//! CODE_ALL_TYPES
 
 const EMPTY_CHAR_CODE = 1;
 const EMPTY_CHAR = String.fromCharCode(EMPTY_CHAR_CODE);

--- a/src/dialogue portraits.js
+++ b/src/dialogue portraits.js
@@ -117,9 +117,7 @@ if (!window.EDITOR) {
 } else {
 	// Pull from CONFIG dynamically when running code in the editor
 	Object.defineProperty(portraitVars, 'SCALE', {
-		get: () => {
-			return parseInt(FIELD(CONFIG, 'scale', 'json'), 10) || 4;
-		},
+		get: () => parseInt(FIELD(CONFIG, 'scale', 'json'), 10) || 4,
 	});
 	Object.defineProperty(portraitVars, 'DEFAULT_SIDE', {
 		get: () => {
@@ -131,9 +129,7 @@ if (!window.EDITOR) {
 		},
 	});
 	Object.defineProperty(portraitVars, 'MARGIN', {
-		get: () => {
-			return parseInt(FIELD(CONFIG, 'margin', 'json'), 10) || 2;
-		},
+		get: () => parseInt(FIELD(CONFIG, 'margin', 'json'), 10) || 2,
 	});
 	Object.defineProperty(portraitVars, 'DEFAULT_BORDER_PALETTE_COLOR', {
 		get: () => {

--- a/src/dialogue portraits.js
+++ b/src/dialogue portraits.js
@@ -116,30 +116,34 @@ if (!window.EDITOR) {
 	}
 } else {
 	// Pull from CONFIG dynamically when running code in the editor
-	Object.defineProperty(portraitVars, 'SCALE', { get: () =>
-	{
-		return parseInt(FIELD(CONFIG, 'scale', 'json'), 10) || 4;
-	}});
-	Object.defineProperty(portraitVars, 'DEFAULT_SIDE', { get: () =>
-	{
-		let result = parseInt(FIELD(CONFIG, 'default-side', 'json'), 10);
-		if (result !== 0 && result !== 1) {
-			result = 0;
-		}
-		return result;
-	}});
-	Object.defineProperty(portraitVars, 'MARGIN', { get: () =>
-	{
-		return parseInt(FIELD(CONFIG, 'margin', 'json'), 10) || 2;
-	}});
-	Object.defineProperty(portraitVars, 'DEFAULT_BORDER_PALETTE_COLOR', { get: () =>
-	{
-		let result = parseInt(FIELD(CONFIG, 'default-border-palette-color', 'json'), 10) || 0;
-		if (result < 0 || result > 7) {
-			result = 0;
-		}
-		return result;
-	}});
+	Object.defineProperty(portraitVars, 'SCALE', {
+		get: () => {
+			return parseInt(FIELD(CONFIG, 'scale', 'json'), 10) || 4;
+		},
+	});
+	Object.defineProperty(portraitVars, 'DEFAULT_SIDE', {
+		get: () => {
+			let result = parseInt(FIELD(CONFIG, 'default-side', 'json'), 10);
+			if (result !== 0 && result !== 1) {
+				result = 0;
+			}
+			return result;
+		},
+	});
+	Object.defineProperty(portraitVars, 'MARGIN', {
+		get: () => {
+			return parseInt(FIELD(CONFIG, 'margin', 'json'), 10) || 2;
+		},
+	});
+	Object.defineProperty(portraitVars, 'DEFAULT_BORDER_PALETTE_COLOR', {
+		get: () => {
+			let result = parseInt(FIELD(CONFIG, 'default-border-palette-color', 'json'), 10) || 0;
+			if (result < 0 || result > 7) {
+				result = 0;
+			}
+			return result;
+		},
+	});
 }
 
 if (!window.EDITOR) {


### PR DESCRIPTION
Some code polish too
- updated order of CONFIG parameters
- Switched CONFIG parameters that represent numbers from "text" to "json"
- Also, added support for using "-" dialogue to clear dialogue state.

Note, ESlint took umbrage with the style I used to code some getters.  I'm fine with the alternate style if that's what you prefer, but the style I used is easier to read IMO, because it focuses on the repetition of the form between all of the getters.