### PR TITLE
new field defaulting to "tag" type has data of true

### DIFF
--- a/src/editor fields start as tags.js
+++ b/src/editor fields start as tags.js
@@ -21,6 +21,7 @@ function setupEditorPlugin() {
 	wrap.after(EventEditor.prototype, 'addField', () => {
 		const { event } = window.EDITOR.getSelections();
 		event.fields[event.fields.length - 1].type = 'tag';
+		event.fields[event.fields.length - 1].data = true;
 		window.EDITOR.eventEditor.refresh();
 	});
 


### PR DESCRIPTION
bug fix - the data of a new field defaulting to the "tag" type must conform to the standard data value of true in case it's directly checked.