### PR TITLE
Don't crash when no event has the is-head tag in the Tall Character plugin

### DIFF
--- a/dist/tall-character.js
+++ b/dist/tall-character.js
@@ -39,8 +39,11 @@ hackOptions.direction = directions[FIELD(CONFIG, 'direction', 'text') || 'up'] |
 
 wrap.before(BipsiPlayback.prototype, 'render', () => {
 	const playback = window.PLAYBACK;
-	const avatar = window.getEventById(playback.data, playback.avatarId);
 	const head = window.findEventByTag(playback.data, 'is-head');
+	if (!head) {
+		return;
+	}
+	const avatar = window.getEventById(playback.data, playback.avatarId);
 	const pos = window.getLocationOfEvent(playback.data, avatar);
 	const newPos = {
 		room: pos.room,

--- a/src/tall character.js
+++ b/src/tall character.js
@@ -32,8 +32,11 @@ hackOptions.direction = directions[FIELD(CONFIG, 'direction', 'text') || 'up'] |
 
 wrap.before(BipsiPlayback.prototype, 'render', () => {
 	const playback = window.PLAYBACK;
-	const avatar = window.getEventById(playback.data, playback.avatarId);
 	const head = window.findEventByTag(playback.data, 'is-head');
+	if (!head) {
+		return;
+	}
+	const avatar = window.getEventById(playback.data, playback.avatarId);
 	const pos = window.getLocationOfEvent(playback.data, avatar);
 	const newPos = {
 		room: pos.room,


### PR DESCRIPTION
The plugin assumes there is always an event with the tag, but maybe the user wants to remove it during gameplay.